### PR TITLE
fix: update zellij action cmd to match default bindings/example

### DIFF
--- a/lua/zellij-nav/utils.lua
+++ b/lua/zellij-nav/utils.lua
@@ -10,7 +10,12 @@ function M.zellij_navigate(short_direction, direction)
   -- Check if window number changed
   if cur_winnr == vim.fn.winnr() then
     -- If window didn't switch, use zellij action to move focus
-    vim.fn.system("zellij action move-focus " .. direction)
+    if direction == "left" or direction == "right" then
+      -- If direction is left or right, need to be able to move tabs
+      vim.fn.system("zellij action move-focus-or-tab " .. direction)
+    else
+      vim.fn.system("zellij action move-focus " .. direction)
+    end
   end
 end
 


### PR DESCRIPTION
Updated the zellij action command to `move-focus-or-tab` to match the behavior in the default and example zellij keybindings.
